### PR TITLE
Fix/global find prefix

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -16,6 +16,7 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_BLANK_FIND_FIELD_INPUT = "Input for find fields cannot be empty! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
+    public static final String MESSAGE_MIX_GLOBAL_AND_PREFIX_SEARCH = "Cannot mix global search with prefixed search.";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_MEETINGS_LISTED_OVERVIEW = "%1$d meetings listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 
 import java.util.List;
 
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.PersonMatchesKeywordsPredicate;
@@ -39,7 +40,7 @@ public class FindCommandParser implements Parser<FindCommand> {
         List<String> phoneKeywords = argMultimap.getAllValues(PREFIX_PHONE);
         List<String> emailKeywords = argMultimap.getAllValues(PREFIX_EMAIL);
 
-        validatePrefixedSearch(args, preamble, nameKeywords, phoneKeywords, emailKeywords);
+        validatePrefixedSearch(preamble, nameKeywords, phoneKeywords, emailKeywords);
 
         return new FindCommand(createPredicate(preamble, nameKeywords, phoneKeywords, emailKeywords));
     }
@@ -49,7 +50,6 @@ public class FindCommandParser implements Parser<FindCommand> {
      * Prevents mixing global search and prefixed search.
      * Ensures that any prefix present is not followed only by blank values.
      *
-     * @param args          User input.
      * @param preamble      Global keywords.
      * @param nameKeywords  Name keywords.
      * @param phoneKeywords Phone keywords.
@@ -57,18 +57,18 @@ public class FindCommandParser implements Parser<FindCommand> {
      * @throws ParseException If the input mixes global and prefixed search,
      *                        or if a supplied prefixed field is blank.
      */
-    private void validatePrefixedSearch(String args, String preamble,
+    private void validatePrefixedSearch(String preamble,
             List<String> nameKeywords,
             List<String> phoneKeywords,
             List<String> emailKeywords) throws ParseException {
-        boolean hasNamePrefix = args.contains(PREFIX_NAME.getPrefix());
-        boolean hasPhonePrefix = args.contains(PREFIX_PHONE.getPrefix());
-        boolean hasEmailPrefix = args.contains(PREFIX_EMAIL.getPrefix());
+        boolean hasNamePrefix = !nameKeywords.isEmpty();
+        boolean hasPhonePrefix = !phoneKeywords.isEmpty();
+        boolean hasEmailPrefix = !emailKeywords.isEmpty();
 
         boolean hasAnyPrefixedSearch = hasNamePrefix || hasPhonePrefix || hasEmailPrefix;
 
         if (!preamble.isEmpty() && hasAnyPrefixedSearch) {
-            throw new ParseException("Cannot mix global search with prefixed search.");
+            throw new ParseException(Messages.MESSAGE_MIX_GLOBAL_AND_PREFIX_SEARCH);
         }
 
         validateFieldInput(hasNamePrefix, nameKeywords);

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_BLANK_FIND_FIELD_INPUT;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_MIX_GLOBAL_AND_PREFIX_SEARCH;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -150,5 +151,18 @@ public class FindCommandParserTest {
 
         assertParseFailure(parser, " p/1234 n/   ",
                 String.format(MESSAGE_BLANK_FIND_FIELD_INPUT, FindCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_mixGlobalAndPrefix_throwsParseException() {
+        assertParseFailure(parser, " Alice n/Alice", MESSAGE_MIX_GLOBAL_AND_PREFIX_SEARCH);
+    }
+
+    @Test
+    public void parse_prefixInPreamble_notCountedAsPrefixSearch() {
+        FindCommand expected = new FindCommand(
+                new PersonMatchesKeywordsPredicate(List.of("Aaron/Tan"), List.of(), List.of(), List.of()));
+        // n/ part of the preamble, not considered a prefix.
+        assertParseSuccess(parser, " Aaron/Tan", expected);
     }
 }


### PR DESCRIPTION
Fixes #256 

Changed the logic of checking for mixed global and prefix search to use the argument multimap instead of `String::contains()`.