### PR TITLE
Fix/update meeting after edit person

### DIFF
--- a/src/main/java/seedu/address/ui/meeting/MeetingListPanel.java
+++ b/src/main/java/seedu/address/ui/meeting/MeetingListPanel.java
@@ -61,6 +61,7 @@ public class MeetingListPanel extends UiPart<Region> {
         }
 
         meetingListView.setItems(items);
+        meetingListView.refresh();
     }
 
     /**


### PR DESCRIPTION
Fixes #280 

Fixed by manually refreshing the meeting list view every time a change in the meeting list is detected.

The cause of the bug is probably because editing a person isn't registered as a "change" by the `ObservableList`. When editing a person, its ID stays the same, and since a `Meeting` only stores the IDs of the participants, it does not detect the change.